### PR TITLE
Mkdir RCDIR in install script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ ${SCRIPTS}:
 
 install:: all
 	$(MKDIR) -p $(BINDIR)
+	$(MKDIR) -p $(RCDIR)
 #	$(MKDIR) -p $(FILESDIR)
 	$(INSTALL) -c -m $(BINMODE) ${.OBJDIR}/$(SCRIPTS) $(BINDIR)/
 #	$(INSTALL) -c ${.OBJDIR}/lib/* $(FILESDIR)/


### PR DESCRIPTION
/usr/local/etc/rc.d/ does not exist on freshly-installed FreeBSD.
