### PR TITLE
after zfs resize, modify also zfs attribute for iohyve:size reflecting the new size

### DIFF
--- a/iohyve
+++ b/iohyve
@@ -981,6 +981,7 @@ __resize(){
 		local running=$(pgrep -fx "bhyve: ioh-$name")
 		if [ -z $running ]; then
 			zfs set volsize=$size $pool/iohyve/$name/$disk
+			zfs set iohyve:size=$size $pool/iohyve/$name
 		else
 			echo "Please stop the guest first"
 		fi


### PR DESCRIPTION
After doing "iohyve resize vm_name disk0 100G", the iohyve:size attribute is not updated.
Thus when doing "iohyve getall vm_name", it returns the old size.
