### PR TITLE
matching properly pool/iohyve

### DIFF
--- a/iohyve
+++ b/iohyve
@@ -248,7 +248,7 @@ __list() {
 	(
         printf "%s^%s^%s^%s^%s\n" "Guest" "VMM?" "Running" "rcboot?" "Description"
 	for pool in $pools; do
-            local guests="$(zfs list -H | grep iohyve | grep -Ev "disk|ISO|Firmware" | grep -i $pool | cut -f1 | cut -d'/' -f3 | sed 1d | uniq)"
+            local guests="$(zfs list -H | grep -i ^$pool/iohyve | grep -Ev "disk|ISO|Firmware" | cut -f1 | cut -d'/' -f3 | sed 1d | uniq)"
             for g in $guests; do
 		local vmm="/dev/vmm/ioh-$g"
 		if [ -e $vmm ]; then


### PR DESCRIPTION
if you have a ZVOL like /backup/iohyve/vm_name then "iohyve list" will match it and will return some garbage error:
# iohyve list

cannot open 'zroot/iohyve/iohyve': dataset does not exist
[: =: unexpected operator
cannot open 'zroot/iohyve/iohyve': dataset does not exist
Guest             VMM?  Running  rcboot?  Description
iohyve            NO    NO       NO
alcsys-vm52       YES   YES      NO       Alcalina preprod
bichono           NO    NO       NO       test vm
debian8-template  NO    NO       NO       Sun_Jan_31_11:30:46_CET_2016
testvm            YES   YES      NO       Fri Jan 29 22:41:30 CET 2016
