### PR TITLE
Enhancement.support multiple tap

### DIFF
--- a/iohyve
+++ b/iohyve
@@ -412,7 +412,7 @@ __create() {
 	fi
 	echo "Creating $name..."
 	zfs create $pool/iohyve/$name
-	zfs create -V $size -o volmode=dev $pool/iohyve/$name/disk0
+	zfs create -V $size -o volmode=dev -o volblocksize=128K $pool/iohyve/$name/disk0
 	zfs set iohyve:name=$name $pool/iohyve/$name
 	zfs set iohyve:size=$size $pool/iohyve/$name
 	zfs set iohyve:ram=256M $pool/iohyve/$name
@@ -935,7 +935,7 @@ __add() {
 	local newdisk="$(expr $lastdisk + 1)"
 	echo "Creating new zvol for $name..."
 	zfs create $newpool/iohyve/$name 2> /dev/null
-	zfs create -V $size -o volmode=dev $newpool/iohyve/$name/disk$newdisk
+	zfs create -V $size -o volmode=dev -o volblocksize=128K $newpool/iohyve/$name/disk$newdisk
 	# Find the last pcidev and increment by one
 	local lastpci="$(zfs get -H all | grep iohyve/$name | grep pcidev | cut -f2 | \
 		cut -d ':' -f3 | sort -V | tail -n1)"

--- a/iohyve
+++ b/iohyve
@@ -648,28 +648,25 @@ __prepare_guest() {
 	local name="$1"
 	local dataset="$(zfs list -H -t volume | grep $name | grep disk0 | cut -d '/' -f 1-3 | head -n1)"
 	local pci="$(__get_zfs_pcidev_conf $dataset)"
-	local tap="$(zfs get -H -o value iohyve:tap $dataset)"
-	local mac="$(zfs get -H -o value iohyve:mac $dataset)"
-	# Setup tap if needed
-	if [ $tap ] && [ $tap != "-" ]; then
-		if [ $tap != "tap0" ]; then
-			# no need to create tap0, should be installed already via README
-			# check to see if tap is already created before attempting to create new tap interface
-			# Simple hacky check for tapif
-			local tapif="$('ifconfig' -l | grep $tap | cut -c1)"
-			if [ -z $tapif ]; then
-				# create tap interface
-				ifconfig $tap create
-				ifconfig bridge0 addm $tap
-			fi
-		fi
-		# Add a virtio-net pci device for the tap
-		if [ $mac = "-" ]; then
-			pci="virtio-net,$tap $pci"
-		else
-			pci="virtio-net,${tap},mac=${mac} $pci"
-		fi
-	fi
+        # Setup tap if needed
+        local listtap="$(zfs get -H -o value iohyve:tap $dataset)"
+        for tap in $(echo $listtap | sed -n 1'p' | tr ',' '\n'); do
+                if [ $tap ] && [ $tap != "-" ]; then
+                        local tapif="$('ifconfig' -a | grep $tap: | cut -c1-4)"
+                        if [ -z $tapif ]; then
+                                # create tap interface
+                                ifconfig $tap create
+                        fi
+
+                        # Add a virtio-net pci device for the tap
+                        local mac="$(zfs get -H -o value iohyve:mac_$tap $dataset)"
+                        if [ $mac = "-" ]; then
+                                pci="virtio-net,$tap $pci"
+                        else
+                                pci="virtio-net,${tap},mac=${mac} $pci"
+                        fi
+                fi
+        done
 	#Add disk as second PCI device
 	pci="ahci-hd,/dev/zvol/$dataset/disk0 $pci"
 	#Add Hostbridge and lpc as the first PCI devices


### PR DESCRIPTION
The proposal patch is to be able to define multiple nic with the respect of the current design of iohyve through the ZFS parameters.

Basically the command would be a list of tap with the comma as delimiter : 

root@dnxsys-hy004:~ # iohyve set dnxsys-pf004 tap=tap1,tap2,tap3,tap4
Setting dnxsys-pf004 prop tap=tap1,tap2,tap3,tap4...

root@dnxsys-hy004:~ # iohyve getall dnxsys-pf004
Getting dnxsys-pf004 props...
cpu              1
os               default
ram              256M
bargs            -A_-H_-P
loader           bhyveload
autogrub         \n
size             8G
description      Mon_Feb__1_19:38:48_CET_2016
iohyve:mac_tap1  00:FF:00:FF:CA:CA
install          no
con              nmdm0
name             dnxsys-pf004
tap              tap1,tap2,tap3,tap4
boot             0
persist          1

In addition it would be possible to define a mac for each defined tap with : 

iohyve set dnxsys-pf004 iohyve:mac_tapX=yyy

ex:

iohyve set dnxsys-pf004 iohyve:mac_tap1=00:FF:00:FF:CA:CA

i successfully installed pfsense with 4 tap by this way.
