### PR TITLE
Add: displays getall correctly when description contains spaces

### DIFF
--- a/iohyve
+++ b/iohyve
@@ -923,9 +923,9 @@ __rmpci() {
 # Get all ZFS props
 __getall() {
 	local name="$2"
-	local pool="$(zfs list -H -t volume | grep $name | grep disk0 | cut -d '/' -f 1 | head -n1)"
-	echo "Getting $name props..."
-	zfs get -H all $pool/iohyve/$name | grep iohyve: | cut -w -f2-3 | cut -c8- | column -t
+	local pool="$(zfs list -H -t volume | grep iohyve/$name | grep disk0 | cut -d '/' -f 1 | head -n1)"
+	echo "Getting $name iohyve properties..."
+	zfs get -o property,value all $pool/iohyve/$name | grep iohyve: | sort | sed -e 's/iohyve://g'
 }
 
 # Fix legacy bhyve arguments


### PR DESCRIPTION
[Address issue as described here](https://github.com/pr1ntf/iohyve/issues/115) for `iohyve getall`, guessing the `export` function is in development. 

Utilizes `zfs` to display the text as desired. I removed the `-H` flag as it’s primary purpose is to make parsing text easier, which we are not doing with the `getall` subcommand. Using `sort` because it drives me crazy to have the order of the options change between guest outputs, this brings it to more consistent output. Using `sed` to replace the text `iohyve:` with nothing.

Also added `iohyve/` to find the pool for consistency within the script.

Before changes:

```
root@bhost:~ # iohyve getall bguest
Getting guest props...
tap tap7001
description pfSense
name    guest
os  pfsense
ram 512M
cpu 2
bargs   -A_-H_-P
con nmdm6
autogrub    \n
size    6G
install no
persist 1
loader  bhyveload
boot    1
```

After changes:

```
root@bhost:~ # iohyve getall bguest
Getting bguest properties...
autogrub       \n
bargs          -A_-H_-P
boot           1
con            nmdm6
cpu            2
description    pfSense - VPN In
install        no
loader         bhyveload
name           bguest
os             pfsense
persist        1
ram            512M
size           6G
tap            tap7001
```
