### PR TITLE
Fix: delete sub-func deletes all guests with similar base name.

### DIFF
--- a/iohyve
+++ b/iohyve
@@ -823,17 +823,24 @@ __delete() {
 	local flagone="$2"
 	local flagtwo="$3"
 	if [ $flagone = "-f" ]; then
-		local datasets="$(zfs list -H -t filesystem -o name | grep iohyve | grep $flagtwo)"
-		echo "Forcing deletion of $flagtwo"
-		for d in $datasets; do zfs destroy -rR $d; done
+		local target_dataset="$(zfs list -H -t filesystem -o name | grep iohyve | grep $flagtwo | head -n1)"
+		echo ""
+		echo "[WARNING] Forcing permanent deletion of $flagtwo"
+		echo "Location: $target_dataset including children and clones"
+		echo ""
+		echo "Hit Ctrl+C in the next 10 seconds to cancel..."
+		sleep 10
+		echo "Deleting $flagtwo at $target_dataset..."
+		zfs destroy -rR $target_dataset
 	else
-		local datasets="$(zfs list -H -t filesystem -o name | grep iohyve | grep $flagone)"
-		read -p "Are you sure you want to delete $flagone and all associated datasets [Y/N]? " an </dev/tty
+		local target_dataset="$(zfs list -H -t filesystem -o name | grep iohyve | grep $flagone | head -n1)"
+		echo ""
+		echo "[WARNING] Are you sure you want to permanently delete $flagone and all child datasets?"
+		read -p "Location: $target_dataset [Y/N]? " an </dev/tty
 		case "$an" in
-			y|Y) for d in $datasets; do zfs destroy -rR $d; done
-			;;
-			*) echo "Not deleted..."
-			;;
+			y|Y) echo "Deleting $flagone at $target_dataset..."; zfs destroy -r $target_dataset
+ 			;;
+			*) echo "$flagone not deleted..."
 		esac
 	fi
 }


### PR DESCRIPTION
Addresses an issue when using the command `iohyve delete` which would actually delete names with the same base name. An example, `basenameguest` and `basenameguest1` would be deleted when using `iohyve delete basenameguest`.

I removed the `for` loops as I believe they are unnecessary when using the `-r` flag with `zfs destroy`. The child datasets (eg iohyve guest disks) should be destroyed when using that flag alone.

Changed `zfs destroy` to use only the `-r` flag when not using the `iohyve delete -f` command as using `zfs destroy -R` transverses to clones. While clones are not currently implemented with `iohyve`, I think as a matter of caution, full destruction mode should be reserved for the use of `iohyve delete -f` instead.

Added various changes to the prompts and output for clarity and verbosity, it is the least we can do for the end user before they do something irreversible.

Excerpt from `man` page for `zfs destroy`:

```
-r  Recursively destroy all children. If a snapshot
    is  specified,  destroy all  snapshots with this
    name in descendent file systems.

-R  Recursively destroy all dependents, including
    cloned file  systems  outside the target hierarchy.
    If a snapshot is specified, destroy all snapshots
    with this name in descendent  file  systems.
```

Before changes:

```
root@bhost:~ # iohyve list
Guest      VMM?  Running  rcboot?  Description
root@bhost:~ # iohyve create basenameguest 1G
printf: Illegal option -\
Creating basenameguest...
root@bhost:~ # iohyve create basenameguest1 1G
printf: Illegal option -\
Creating basenameguest1...
root@bhost:~ # iohyve list
Guest           VMM?  Running  rcboot?  Description
basenameguest   NO    NO       NO       Sun Apr  3 09:09:45 MDT 2016
basenameguest1  NO    NO       NO       Sun Apr  3 09:09:54 MDT 2016
root@bhost:~ # zfs list -H -t filesystem -o name | grep iohyve | grep basenameguest
tank/iohyve/basenameguest
tank/iohyve/basenameguest1
root@bhost:~ # iohyve delete basenameguest
Are you sure you want to delete basenameguest and all associated datasets [Y/N]? y
root@bhost:~ # iohyve list
Guest      VMM?  Running  rcboot?  Description
```

After changes:

```
root@bhost:~ # iohyve list
Guest      VMM?  Running  rcboot?  Description
root@bhost:~ # iohyve create basenameguest 1G
printf: Illegal option -\
Creating basenameguest...
root@bhost:~ # iohyve create basenameguest1 1G
printf: Illegal option -\
Creating basenameguest1...
root@bhost:~ # iohyve list
Guest           VMM?  Running  rcboot?  Description
basenameguest   NO    NO       NO       Sun Apr  3 12:06:34 MDT 2016
basenameguest1  NO    NO       NO       Sun Apr  3 12:06:41 MDT 2016
root@bhost:~ # iohyve delete basenameguest

[WARNING] Are you sure you want to permanently delete basenameguest and all child datasets?
Location: tank/iohyve/basenameguest [Y/N]? y
Deleting basenameguest at tank/iohyve/basenameguest...
root@bhost:~ # iohyve list
Guest           VMM?  Running  rcboot?  Description
basenameguest1  NO    NO       NO       Sun Apr  3 12:06:41 MDT 2016

root@bhost:~ # iohyve create basenameguest 1G
printf: Illegal option -\
Creating basenameguest...
root@bhost:~ # iohyve list
Guest           VMM?  Running  rcboot?  Description
basenameguest   NO    NO       NO       Sun Apr  3 12:07:24 MDT 2016
basenameguest1  NO    NO       NO       Sun Apr  3 12:06:41 MDT 2016
root@bhost:~ # iohyve delete -f basenameguest

[WARNING] Forcing permanent deletion of basenameguest
Location: tank/iohyve/basenameguest including children and clones

Hit Ctrl+C in the next 10 seconds to cancel...
Deleting basenameguest at tank/iohyve/basenameguest...
root@bhost:~ # iohyve list
Guest           VMM?  Running  rcboot?  Description
basenameguest1  NO    NO       NO       Sun Apr  3 12:06:41 MDT 2016
```
