### PR TITLE
Add: CentOS/RHEL ver 7 to compatible guests and docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ iohyve set archguest os=arch
 iohyve install archguest archlinux-2015.10.01-dual.iso
 iohyve console archguest
 ````
-Try out CentOS or RHEL _(note version 6 would use os=centos6)
+Try out CentOS or RHEL (note version 6 would use os=centos6):
 ````
 iohyve set centosguest loader=grub-bhyve
 iohyve set centosguest os=centos7

--- a/README.md
+++ b/README.md
@@ -224,3 +224,4 @@ iohyve set centosguest loader=grub-bhyve
 iohyve set centosguest os=centos7
 iohyve install centosguest CentOS-7-x86_64-Everything-1511.iso
 iohyve console centosguest
+````

--- a/README.md
+++ b/README.md
@@ -218,3 +218,9 @@ iohyve set archguest os=arch
 iohyve install archguest archlinux-2015.10.01-dual.iso
 iohyve console archguest
 ````
+Try out CentOS or RHEL _(note version 6 would use os=centos6)
+````
+iohyve set centosguest loader=grub-bhyve
+iohyve set centosguest os=centos7
+iohyve install centosguest CentOS-7-x86_64-Everything-1511.iso
+iohyve console centosguest

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ iohyve set archguest os=arch
 iohyve install archguest archlinux-2015.10.01-dual.iso
 iohyve console archguest
 ````
-Try out CentOS or RHEL (note version 6 would use os=centos6):
+Try out CentOS or RHEL _(note version 6 would use os=centos6)_:
 ````
 iohyve set centosguest loader=grub-bhyve
 iohyve set centosguest os=centos7

--- a/iohyve
+++ b/iohyve
@@ -518,7 +518,7 @@ __load() {
 				printf '\(cd0\)\ '$media'\n' >> /iohyve/$name/device.map
 				printf '\n' | \
 				grub-bhyve $wire_memory -m /iohyve/$name/device.map -r cd0 -M $ram ioh-$name  > /dev/null
-			elif [ $os = "centos6" ]; then
+			elif [ $os = "centos6" ] || [ $os = "centos7" ]; then
 				printf '\(hd0\)\ /dev/zvol/'$disk'\n' > /iohyve/$name/device.map
 				printf '\(cd0\)\ '$media'\n' >> /iohyve/$name/device.map
 				printf 'linux (cd0)/isolinux/vmlinuz\ninitrd (cd0)/isolinux/initrd.img\nboot\n' | \
@@ -569,6 +569,11 @@ __load() {
 				printf '\(cd0\)\ '$media'\n' >> /iohyve/$name/device.map
 				printf '\n' | \
 				grub-bhyve $wire_memory -m /iohyve/$name/device.map -r hd0,msdos1 -d /grub -M $ram ioh-$name  > /dev/null
+			elif [ $os = "centos7" ]; then
+				printf '\(hd0\)\ /dev/zvol/'$disk'\n' > /iohyve/$name/device.map
+				printf '\(cd0\)\ '$media'\n' >> /iohyve/$name/device.map
+				printf '\n' | \
+				grub-bhyve $wire_memory -m /iohyve/$name/device.map -r hd0,msdos1 -d /grub2 -M $ram ioh-$name  > /dev/null
 			elif [ $os = "custom" ]; then
 				printf '\(hd0\)\ /dev/zvol/'$disk'\n' > /iohyve/$name/device.map
 				printf '\(cd0\)\ '$media'\n' >> /iohyve/$name/device.map


### PR DESCRIPTION
This pull request adds the ability to install and run CentOS 7 and RHEL 7 guests.

The install portion is identical to the centos6 guest. As for the regular start section,
the directory must point to `/grub2` rather than `/grub`.

This patch was tested against the releases below as follows:

**CentOS 7 Everything 1511 disc**

```
iohyve create centosguest 10G
iohyve set ram=1G
iohyve set centosguest loader=grub-bhyve
iohyve set centosguest os=centos7
iohyve install centosguest CentOS-7-x86_64-Everything-1511.iso
iohyve console centosguest
```

Configured for minimal installation on LVM && `btrfs` && traditional `xfs`
Installs fine.

```
iohyve destroy centosguest
iohyve start centosguest
```

Starts fine.

**RHEL Server 7.2**

```
iohyve create centosguest 10G
iohyve set ram=1G
iohyve set centosguest loader=grub-bhyve
iohyve set centosguest os=centos7
iohyve install centosguest rhel-server-7.2-x86_64-dvd.iso
iohyve console centosguest
```

Configured for minimal installation on LVM
Installs fine.

```
iohyve destroy centosguest
iohyve start centosguest
```

Starts fine.
