### PR TITLE
fixed a typo on the fw variable in __renamefw

### DIFF
--- a/iohyve
+++ b/iohyve
@@ -379,11 +379,12 @@ __cpfw() {
 # Rename Firmware
 __renamefw() {
 	local pool="$(zfs list -H | grep iohyve | cut -d '/' -f 1 | head -n1)"
-	local isfw="$2"
+	local fw="$2"
 	local name="$3"
 	echo "Renaming Firmware $2 to $3..."
 	mv /iohyve/Firmware/$fw/$fw /iohyve/Firmware/$fw/$name
 	zfs rename $pool/iohyve/Firmware/$fw $pool/iohyve/Firmware/$name
+	zfs set mountpoint=/iohyve/Firmware/$name $pool/iohyve/Firmware/$name
 }
 
 # Delete Firmware

--- a/iohyve
+++ b/iohyve
@@ -345,7 +345,6 @@ __renameiso() {
 	echo "Renaming ISO $2 to $3..."
 	mv /iohyve/ISO/$iso/$iso /iohyve/ISO/$iso/$name
 	zfs rename $pool/iohyve/ISO/$iso $pool/iohyve/ISO/$name
-	zfs set mountpoint=/iohyve/ISO/$name $pool/iohyve/ISO/$name
 }
 
 # Delete ISO
@@ -384,7 +383,6 @@ __renamefw() {
 	echo "Renaming Firmware $2 to $3..."
 	mv /iohyve/Firmware/$fw/$fw /iohyve/Firmware/$fw/$name
 	zfs rename $pool/iohyve/Firmware/$fw $pool/iohyve/Firmware/$name
-	zfs set mountpoint=/iohyve/Firmware/$name $pool/iohyve/Firmware/$name
 }
 
 # Delete Firmware

--- a/iohyve
+++ b/iohyve
@@ -345,6 +345,7 @@ __renameiso() {
 	echo "Renaming ISO $2 to $3..."
 	mv /iohyve/ISO/$iso/$iso /iohyve/ISO/$iso/$name
 	zfs rename $pool/iohyve/ISO/$iso $pool/iohyve/ISO/$name
+	zfs set mountpoint=/iohyve/ISO/$name $pool/iohyve/ISO/$name
 }
 
 # Delete ISO


### PR DESCRIPTION
<del>When renaming an ISO or FW the ZFS mount point is not updated to reflect the new name. This results in having device.map's that point to non existent files.</del>


I have <del>also</del> fixed a typo on the fw variable in __renamefw,
