### PR TITLE
Fix for tap

### DIFF
--- a/lib/ioh-guest
+++ b/lib/ioh-guest
@@ -536,6 +536,7 @@ __uefi() {
 				-l com1,/dev/${con}A \
 				-l bootrom,/iohyve/Firmware/$fw/$fw \
 				ioh-$name &
+			ifconfig $tap up
 		else
 			echo "Guest is already running."
 		fi


### PR DESCRIPTION
[Google translate DE->EN]
In my situation tapX is "DOWN" after the start in UEFI mode.
Device: re0, Realtek 8168/8111

P.S. The hardware is new and has no problems (i used stress test in Sandra)
