### PR TITLE
Refine setup command

### DIFF
--- a/lib/ioh-setup
+++ b/lib/ioh-setup
@@ -127,7 +127,7 @@ __load_kernel_modules() {
 
 __setup_network() {
 	iface=$1
-	local bridgeif="$('ifconfig' -l | grep -F "bridge0 " | cut -c1)"
+	local bridgeif="$('ifconfig' -l | grep -F "bridge0" | cut -c1)"
 	if [ -z $bridgeif ]; then
 		echo "Seting up bridge0 on $iface..."
 		if ! sysctl net.link.tap.up_on_open=1 > /dev/null 2>&1; then

--- a/lib/ioh-setup
+++ b/lib/ioh-setup
@@ -2,96 +2,112 @@
 
 # Setup iohyve
 __setup() {
+	shift 1
 	local args="$@"
 	for arg in $args; do
-		if [ $arg != "setup" ]; then
-			local prop="$(echo $arg | cut -d '=' -f1)"
-			local val="$(echo $arg | cut -d '=' -f2)"
-			if [ $prop = "pool" ]; then
-				local pool="$val"
-				local poolexist="$(zfs list -H | grep ${pool}/iohyve | head -n1 | cut -c1)"
-				if [ -z $poolexist ]; then
-					echo "Setting up iohyve pool..."
-					zfs create $pool/iohyve
-					# iohyve is already setup on a pool
-					if [ -d /iohyve/ISO ]; then
-						echo "Secondary pool set up..."
-						zfs set mountpoint="/iohyve/$pool" $pool/iohyve
-						# iohyve is not set up yet
-					else
-						zfs set mountpoint="/iohyve" $pool/iohyve
-						zfs create $pool/iohyve/ISO
-						zfs create $pool/iohyve/Firmware
-					fi
+		local prop="$(echo $arg | cut -d '=' -f1)"
+		local val="$(echo $arg | cut -d '=' -f2)"
+		if [ $prop = "pool" ]; then
+			local pool="$val"
+			local poolexist="$(zfs list -H | grep ${pool}/iohyve | head -n1 | cut -c1)"
+			if [ -z $poolexist ]; then
+				echo "Setting up iohyve pool..."
+				zfs create $pool/iohyve
+				# iohyve is already setup on a pool
+				if [ -d /iohyve/ISO ]; then
+					echo "Secondary pool set up..."
+					zfs set mountpoint="/iohyve/$pool" $pool/iohyve
+					# iohyve is not set up yet
 				else
-					echo "iohyve already exists on $pool"
+					zfs set mountpoint="/iohyve" $pool/iohyve
+					zfs create $pool/iohyve/ISO
+					zfs create $pool/iohyve/Firmware
 				fi
-				# Checks to see if on FreeNAS
-				# The web UI references this file to display the version
-				if [ -e /etc/version ]; then
-					local OS=$( cat /etc/version | cut -d - -f1 )
-					if [ "$OS" = "FreeNAS" ]; then
-						echo "On FreeNAS installation."
-						echo "Checking for symbolic link to /iohyve from /mnt/iohyve..."
-						if [ -d /mnt/iohyve ]; then
-							if [ ! -e /iohyve ]; then
-								ln -s /mnt/iohyve /iohyve
-								if [ -L /iohyve ]; then
-									echo "Symbolic link to /iohyve from /mnt/iohyve successfully created."
-								else
-									echo "Failed to create symbolic link."
-									echo "Please manually do so by running the following as root:"
-									echo "# ln -s /mnt/iohyve /iohyve"
-								fi
-							elif [ -L /iohyve ]; then
-								echo "Symbolic link to /iohyve already exists."
+			else
+				echo "iohyve already exists on $pool"
+			fi
+			# Checks to see if on FreeNAS
+			# The web UI references this file to display the version
+			if [ -e /etc/version ]; then
+				local OS=$( cat /etc/version | cut -d - -f1 )
+				if [ "$OS" = "FreeNAS" ]; then
+					echo "On FreeNAS installation."
+					echo "Checking for symbolic link to /iohyve from /mnt/iohyve..."
+					if [ -d /mnt/iohyve ]; then
+						if [ ! -e /iohyve ]; then
+							ln -s /mnt/iohyve /iohyve
+							if [ -L /iohyve ]; then
+								echo "Symbolic link to /iohyve from /mnt/iohyve successfully created."
+							else
+								echo "Failed to create symbolic link."
+								echo "Please manually do so by running the following as root:"
+								echo "# ln -s /mnt/iohyve /iohyve"
 							fi
-						elif [ "$val" = "freenas-boot" ] && [ -d /iohyve ]; then
-							echo "Symbolic link not needed. /iohyve exists."
-							echo "iohyve is installed on the freenas-boot pool."
-							echo "This is not recommended configuration."
-						else
-							echo "iohyve does not seem to be setup."
+						elif [ -L /iohyve ]; then
+							echo "Symbolic link to /iohyve already exists."
 						fi
-					fi
-				fi
-			elif [ $prop = "kmod" ]; then
-				if [ $val = "1" ]; then
-					echo "Loading kernel modules..."
-					kldload vmm
-					kldload nmdm
-					kldload if_bridge
-					kldload if_tap
-				elif [ $val = "0" ]; then
-					echo "Unloading kernel modules..."
-					kldunload vmm
-					kldunload nmdm
-					kldunload if_bridge
-					kldunload if_tap
-				else
-					echo "Improper syntax"
-					echo "kmod=1 to load modules"
-					echo "kmod=0 to unload modules"
-				fi
-			elif [ $prop = "net" ]; then
-				local bridgeif="$('ifconfig' -l | grep -F "bridge0 " | cut -c1)"
-				if [ -z $bridgeif ]; then
-					echo "Seting up bridge0 on $val..."
-					sysctl net.link.tap.up_on_open=1
-					ifconfig bridge0 create descr "iohyve-bridge"
-					ifconfig bridge0 addm $val
-					ifconfig bridge0 up
-				else
-					echo "bridge0 is already enabled on this machine..."
-					local sysctlexist="$(sysctl net.link.tap.up_on_open | grep 1 | cut -c1)"
-					if [ -z $sysctlexist ]; then
-						echo "Setting up correct sysctl value..."
-						sysctl net.link.tap.up_on_open=1
+					elif [ "$val" = "freenas-boot" ] && [ -d /iohyve ]; then
+						echo "Symbolic link not needed. /iohyve exists."
+						echo "iohyve is installed on the freenas-boot pool."
+						echo "This is not recommended configuration."
 					else
-						echo "sysctl already setup properly as well..."
+						echo "iohyve does not seem to be setup."
 					fi
 				fi
 			fi
+		elif [ $prop = "kmod" ]; then
+			if [ $val = "1" ]; then
+				echo "Loading kernel modules..."
+				if ! $(kldstat -q -m vmm); then
+					kldload vmm
+				fi
+				if ! $(kldstat -q -m nmdm); then
+					kldload nmdm
+				fi
+				if ! $(kldstat -q -m if_bridge); then
+					kldload if_bridge
+				fi
+				if ! $(kldstat -q -m if_tap); then
+					kldload if_tap
+				fi
+			elif [ $val = "0" ]; then
+				echo "Unloading kernel modules..."
+				if $(kldstat -q -m vmm); then
+					kldunload vmm
+				fi
+				if $(kldstat -q -m nmdm); then
+					kldunload nmdm
+				fi
+				if $(kldstat -q -m if_bridge); then
+					kldunload if_bridge
+				fi
+				if $(kldstat -q -m if_tap); then
+					kldunload if_tap
+				fi
+			else
+				echo "Improper syntax"
+				echo "kmod=1 to load modules"
+				echo "kmod=0 to unload modules"
+			fi
+		elif [ $prop = "net" ]; then
+			local bridgeif="$('ifconfig' -l | grep -F "bridge0 " | cut -c1)"
+			if [ -z $bridgeif ]; then
+				echo "Seting up bridge0 on $val..."
+				sysctl net.link.tap.up_on_open=1
+				ifconfig bridge0 create descr "iohyve-bridge"
+				ifconfig bridge0 addm $val
+				ifconfig bridge0 up
+			else
+				echo "bridge0 is already enabled on this machine..."
+				local sysctlexist="$(sysctl net.link.tap.up_on_open | grep 1 | cut -c1)"
+				if [ -z $sysctlexist ]; then
+					echo "Setting up correct sysctl value..."
+					sysctl net.link.tap.up_on_open=1
+				else
+					echo "sysctl already setup properly as well..."
+				fi
+			fi
 		fi
+		
 	done
 }

--- a/lib/ioh-setup
+++ b/lib/ioh-setup
@@ -8,106 +8,125 @@ __setup() {
 		local prop="$(echo $arg | cut -d '=' -f1)"
 		local val="$(echo $arg | cut -d '=' -f2)"
 		if [ $prop = "pool" ]; then
-			local pool="$val"
-			local poolexist="$(zfs list -H | grep ${pool}/iohyve | head -n1 | cut -c1)"
-			if [ -z $poolexist ]; then
-				echo "Setting up iohyve pool..."
-				zfs create $pool/iohyve
-				# iohyve is already setup on a pool
-				if [ -d /iohyve/ISO ]; then
-					echo "Secondary pool set up..."
-					zfs set mountpoint="/iohyve/$pool" $pool/iohyve
-					# iohyve is not set up yet
-				else
-					zfs set mountpoint="/iohyve" $pool/iohyve
-					zfs create $pool/iohyve/ISO
-					zfs create $pool/iohyve/Firmware
-				fi
-			else
-				echo "iohyve already exists on $pool"
-			fi
-			# Checks to see if on FreeNAS
-			# The web UI references this file to display the version
-			if [ -e /etc/version ]; then
-				local OS=$( cat /etc/version | cut -d - -f1 )
-				if [ "$OS" = "FreeNAS" ]; then
-					echo "On FreeNAS installation."
-					echo "Checking for symbolic link to /iohyve from /mnt/iohyve..."
-					if [ -d /mnt/iohyve ]; then
-						if [ ! -e /iohyve ]; then
-							ln -s /mnt/iohyve /iohyve
-							if [ -L /iohyve ]; then
-								echo "Symbolic link to /iohyve from /mnt/iohyve successfully created."
-							else
-								echo "Failed to create symbolic link."
-								echo "Please manually do so by running the following as root:"
-								echo "# ln -s /mnt/iohyve /iohyve"
-							fi
-						elif [ -L /iohyve ]; then
-							echo "Symbolic link to /iohyve already exists."
-						fi
-					elif [ "$val" = "freenas-boot" ] && [ -d /iohyve ]; then
-						echo "Symbolic link not needed. /iohyve exists."
-						echo "iohyve is installed on the freenas-boot pool."
-						echo "This is not recommended configuration."
-					else
-						echo "iohyve does not seem to be setup."
-					fi
-				fi
-			fi
+			__setup_pool $val
 		elif [ $prop = "kmod" ]; then
-			if [ $val = "1" ]; then
-				echo "Loading kernel modules..."
-				if ! $(kldstat -q -m vmm); then
-					kldload vmm
-				fi
-				if ! $(kldstat -q -m nmdm); then
-					kldload nmdm
-				fi
-				if ! $(kldstat -q -m if_bridge); then
-					kldload if_bridge
-				fi
-				if ! $(kldstat -q -m if_tap); then
-					kldload if_tap
-				fi
-			elif [ $val = "0" ]; then
-				echo "Unloading kernel modules..."
-				if $(kldstat -q -m vmm); then
-					kldunload vmm
-				fi
-				if $(kldstat -q -m nmdm); then
-					kldunload nmdm
-				fi
-				if $(kldstat -q -m if_bridge); then
-					kldunload if_bridge
-				fi
-				if $(kldstat -q -m if_tap); then
-					kldunload if_tap
-				fi
-			else
-				echo "Improper syntax"
-				echo "kmod=1 to load modules"
-				echo "kmod=0 to unload modules"
-			fi
+			__load_kernel_modules $val
 		elif [ $prop = "net" ]; then
-			local bridgeif="$('ifconfig' -l | grep -F "bridge0 " | cut -c1)"
-			if [ -z $bridgeif ]; then
-				echo "Seting up bridge0 on $val..."
-				sysctl net.link.tap.up_on_open=1
-				ifconfig bridge0 create descr "iohyve-bridge"
-				ifconfig bridge0 addm $val
-				ifconfig bridge0 up
-			else
-				echo "bridge0 is already enabled on this machine..."
-				local sysctlexist="$(sysctl net.link.tap.up_on_open | grep 1 | cut -c1)"
-				if [ -z $sysctlexist ]; then
-					echo "Setting up correct sysctl value..."
-					sysctl net.link.tap.up_on_open=1
-				else
-					echo "sysctl already setup properly as well..."
-				fi
-			fi
+			__setup_network $val
 		fi
 		
 	done
+}
+
+__setup_pool() {
+	local pool="$1"
+	local poolexist="$(zfs list -H | grep ${pool}/iohyve | head -n1 | cut -c1)"
+	if [ -z $poolexist ]; then
+		echo "Setting up iohyve pool..."
+		zfs create $pool/iohyve
+		# iohyve is already setup on a pool
+		if [ -d /iohyve/ISO ]; then
+			echo "Secondary pool set up..."
+			zfs set mountpoint="/iohyve/$pool" $pool/iohyve
+			# iohyve is not set up yet
+		else
+			zfs set mountpoint="/iohyve" $pool/iohyve
+			zfs create $pool/iohyve/ISO
+			zfs create $pool/iohyve/Firmware
+		fi
+	else
+		echo "iohyve already exists on $pool"
+	fi
+	# Checks to see if on FreeNAS
+	# The web UI references this file to display the version
+	if [ -e /etc/version ]; then
+		local OS=$( cat /etc/version | cut -d - -f1 )
+		if [ "$OS" = "FreeNAS" ]; then
+			setup_freenas $val
+		fi
+	fi
+}
+
+__setup_freenas() {
+	val=$1
+	echo "On FreeNAS installation."
+	echo "Checking for symbolic link to /iohyve from /mnt/iohyve..."
+	if [ -d /mnt/iohyve ]; then
+		if [ ! -e /iohyve ]; then
+			ln -s /mnt/iohyve /iohyve
+			if [ -L /iohyve ]; then
+				echo "Symbolic link to /iohyve from /mnt/iohyve successfully created."
+			else
+				echo "Failed to create symbolic link."
+				echo "Please manually do so by running the following as root:"
+				echo "# ln -s /mnt/iohyve /iohyve"
+			fi
+		elif [ -L /iohyve ]; then
+			echo "Symbolic link to /iohyve already exists."
+		fi
+	elif [ "$val" = "freenas-boot" ] && [ -d /iohyve ]; then
+		echo "Symbolic link not needed. /iohyve exists."
+		echo "iohyve is installed on the freenas-boot pool."
+		echo "This is not recommended configuration."
+	else
+		echo "iohyve does not seem to be setup."
+	fi
+}
+
+__load_kernel_modules() {
+	val=$1
+	if [ $val = "1" ]; then
+		echo "Loading kernel modules..."
+		if ! $(kldstat -q -m vmm); then
+			kldload vmm
+		fi
+		if ! $(kldstat -q -m nmdm); then
+			kldload nmdm
+		fi
+		if ! $(kldstat -q -m if_bridge); then
+			kldload if_bridge
+		fi
+		if ! $(kldstat -q -m if_tap); then
+			kldload if_tap
+		fi
+	elif [ $val = "0" ]; then
+		echo "Unloading kernel modules..."
+		if $(kldstat -q -m vmm); then
+			kldunload vmm
+		fi
+		if $(kldstat -q -m nmdm); then
+			kldunload nmdm
+		fi
+		if $(kldstat -q -m if_bridge); then
+			kldunload if_bridge
+		fi
+		if $(kldstat -q -m if_tap); then
+			kldunload if_tap
+		fi
+	else
+		echo "Improper syntax"
+		echo "kmod=1 to load modules"
+		echo "kmod=0 to unload modules"
+	fi
+}
+
+__setup_network() {
+	iface=$1
+	local bridgeif="$('ifconfig' -l | grep -F "bridge0 " | cut -c1)"
+	if [ -z $bridgeif ]; then
+		echo "Seting up bridge0 on $iface..."
+		sysctl net.link.tap.up_on_open=1
+		ifconfig bridge0 create descr "iohyve-bridge"
+		ifconfig bridge0 addm $iface
+		ifconfig bridge0 up
+	else
+		echo "bridge0 is already enabled on this machine..."
+		local sysctlexist="$(sysctl net.link.tap.up_on_open | grep 1 | cut -c1)"
+		if [ -z $sysctlexist ]; then
+			echo "Setting up correct sysctl value..."
+			sysctl net.link.tap.up_on_open=1
+		else
+			echo "sysctl already setup properly as well..."
+		fi
+	fi
 }

--- a/lib/ioh-setup
+++ b/lib/ioh-setup
@@ -63,7 +63,7 @@ __setup_pool() {
 }
 
 __setup_freenas() {
-	val=$1
+	local val=$1
 	echo "On FreeNAS installation."
 	echo "Checking for symbolic link to /iohyve from /mnt/iohyve..."
 	if [ -d /mnt/iohyve ]; then
@@ -89,7 +89,7 @@ __setup_freenas() {
 }
 
 __load_kernel_modules() {
-	val=$1
+	local val=$1
 	if [ $val = "1" ]; then
 		echo "Loading kernel modules..."
 		if ! $(kldstat -q -m vmm); then
@@ -126,7 +126,7 @@ __load_kernel_modules() {
 }
 
 __setup_network() {
-	iface=$1
+	local iface=$1
 	local bridgeif="$('ifconfig' -l | grep -F "bridge0" | cut -c1)"
 	if [ -z $bridgeif ]; then
 		echo "Seting up bridge0 on $iface..."

--- a/lib/ioh-setup
+++ b/lib/ioh-setup
@@ -4,24 +4,39 @@
 __setup() {
 	shift 1
 	local args="$@"
+	local poolval
+	local kmodval
+	local netval
+
 	for arg in $args; do
 		local prop="$(echo $arg | cut -d '=' -f1)"
 		local val="$(echo $arg | cut -d '=' -f2)"
 		if [ $prop = "pool" ]; then
-			__setup_pool $val
+			poolval=$val
 		elif [ $prop = "kmod" ]; then
-			__load_kernel_modules $val
+			kmodval=$val
 		elif [ $prop = "net" ]; then
-			__setup_network $val
+			netval=$val
 		fi
 		
 	done
+	
+	# Run commands in correct order, so that the kernel modules are loaded
+	# before the network is setup
+	if [ ! -z $poolval ]; then
+		__setup_pool $poolval
+	fi
+	if [ ! -z $kmodval ]; then
+		__load_kernel_modules $kmodval
+	fi
+	if [ ! -z $netval ]; then
+		__setup_network $netval
+	fi
 }
 
 __setup_pool() {
 	local pool="$1"
-	local poolexist="$(zfs list -H | grep ${pool}/iohyve | head -n1 | cut -c1)"
-	if [ -z $poolexist ]; then
+	if ! zfs list ${pool}/iohyve > /dev/null 2>&1; then
 		echo "Setting up iohyve pool..."
 		zfs create $pool/iohyve
 		# iohyve is already setup on a pool
@@ -115,14 +130,21 @@ __setup_network() {
 	local bridgeif="$('ifconfig' -l | grep -F "bridge0 " | cut -c1)"
 	if [ -z $bridgeif ]; then
 		echo "Seting up bridge0 on $iface..."
-		sysctl net.link.tap.up_on_open=1
+		if ! sysctl net.link.tap.up_on_open=1 > /dev/null 2>&1; then
+			echo "cannot set 'net.link.tap.up_on_open': is if_tap loaded?"
+		fi
 		ifconfig bridge0 create descr "iohyve-bridge"
 		ifconfig bridge0 addm $iface
 		ifconfig bridge0 up
 	else
 		echo "bridge0 is already enabled on this machine..."
-		local sysctlexist="$(sysctl net.link.tap.up_on_open | grep 1 | cut -c1)"
-		if [ -z $sysctlexist ]; then
+		local sysctlexist
+		if ! sysctlexist="$(sysctl -n net.link.tap.up_on_open 2> /dev/null)"; then
+			echo "cannot set 'net.link.tap.up_on_open': is if_tap loaded?"
+			return 1
+		fi
+
+		if [ $sysctlexist = "0" ]; then
 			echo "Setting up correct sysctl value..."
 			sysctl net.link.tap.up_on_open=1
 		else

--- a/lib/ioh-setup
+++ b/lib/ioh-setup
@@ -129,7 +129,7 @@ __setup_network() {
 	local iface=$1
 	local bridgeif="$('ifconfig' -l | grep -F "bridge0" | cut -c1)"
 	if [ -z $bridgeif ]; then
-		echo "Seting up bridge0 on $iface..."
+		echo "Setting up bridge0 on $iface..."
 		if ! sysctl net.link.tap.up_on_open=1 > /dev/null 2>&1; then
 			echo "cannot set 'net.link.tap.up_on_open': is if_tap loaded?"
 		fi


### PR DESCRIPTION
I changed some things in the setup method.
1. Load/Unload kernel modules only when necessary
2. Moved all setup operations to separate functions
3. Changed the setup to always run in the same order (pool -> kernel modules -> network)
4. Fixed a bug for detecting if bridge0 is already set up (removed a whitespace from the grep statement)
