### PR TITLE
Removed the cat from CPU feature detection

### DIFF
--- a/iohyve
+++ b/iohyve
@@ -6,8 +6,8 @@
 PATH=${PATH}:/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin
 
 # Check to see if CPU is compatible with bhyve
-if [ $( cat /var/run/dmesg.boot | grep 'POPCNT' ) ]; then
-	if [ -n "$( cat /var/run/dmesg.boot | grep 'CPU:' | grep 'Intel' )" ] && [ -z "$( cat /var/run/dmesg.boot | grep 'VT-x:' | grep 'UG' )" ]; then
+if [ $( grep 'POPCNT' /var/run/dmesg.boot ) ]; then
+	if [ -n "$( grep 'CPU:' /var/run/dmesg.boot | grep 'Intel' )" ] && [ -z "$( grep 'VT-x:' /var/run/dmesg.boot | grep 'UG' )" ]; then
 		echo "Your CPU does not seem to fully support bhyve. Missing UG feature on Intel CPU, please upgrade to 5600 series."
 		exit 1
 	fi


### PR DESCRIPTION
Not needed to use cat, grep can directly search in the file.
