### PR TITLE
enable set -x for debugging when requested

### DIFF
--- a/lib/ioh-cmd
+++ b/lib/ioh-cmd
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+if [ $IOH_DEBUG ]; then
+	set -x
+fi
+
 # Check whether a given command requires root
 __root_req_cmd () {
 		case "$1" in


### PR DESCRIPTION
Would make it much easier to modify if you could toggle set -x easily.
