### PR TITLE
More specific grep for VMs with more than one disk

### DIFF
--- a/lib/ioh-guest
+++ b/lib/ioh-guest
@@ -302,7 +302,7 @@ __guest_load() {
 		return 1
 	fi
 
-	local disk="${3-$(zfs get -H -t volume -o name,value iohyve:name | grep "$(printf '\t')$name$" | cut -f1)}"
+	local disk="${3-$(zfs get -H -t volume -o name,value iohyve:name | grep "$(printf 'disk0\t')$name$" | cut -f1)}"
 	local dataset="$(zfs get -H -o name,value -s local,received -t filesystem iohyve:name | grep "$(printf '\t')$name$" | cut -f1)"
 	local ram="$(zfs get -H -o value iohyve:ram $dataset)"
 	local con="$(zfs get -H -o value iohyve:con $dataset)"


### PR DESCRIPTION
I'm not really sure this is the best way to solve this -- perhaps we should have a property to specify the disk to use in device.map?

I imagine almost everyone will want disk0 anyway (I can't think of a reason why I wouldn't) and it solves https://github.com/pr1ntf/iohyve/issues/203 for me.

(edit: wrong issue number, doh!)
