### PR TITLE
Fix installing to a custom PREFIX.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ install:: all
 	$(MKDIR) -p $(BINDIR)
 	$(MKDIR) -p $(RCDIR)
 	$(MKDIR) -p $(FILESDIR)
+	$(MKDIR) -p $(MANDIR)
 	$(INSTALL) -c -m $(BINMODE) ${.OBJDIR}/$(SCRIPTS) $(BINDIR)/
 	$(INSTALL) -c ${.OBJDIR}/lib/* $(FILESDIR)/
 	$(INSTALL) -c ${.OBJDIR}/rc.d/* $(RCDIR)/


### PR DESCRIPTION
$(MANDIR) wasn't being created, so the install failed when installing to a custom prefix.