### PR TITLE
Fix issue# 210: iohyve create failing without pool name.

### DIFF
--- a/lib/ioh-guest
+++ b/lib/ioh-guest
@@ -163,7 +163,7 @@ __guest_create() {
 	local pool="${4-$(zfs get -H -s local,received -o name -t filesystem iohyve:name | head -n1 | cut -f1 -d/)}"
 	local size="$3"
 	if [ -z $pool ]; then
-		local pool="$(zfs list -H | grep /iohyve/ISO | cut -f1 -d/ |tail -n1)"
+		local pool="$(zfs list -H | grep /iohyve/ISO | grep -v /iohyve/ISO/ | cut -f1 -d/ |tail -n1)"
 	fi
 	if [ -z $size ]; then
 		printf "missing argument\nusage:\n"


### PR DESCRIPTION
This contains my suggested fix for issue# 210, where iohyve create
failed the first time if no pool name was provided, and cpiso had been
used prior to create. Without this, all of the datasets for the isos get
listed in addition to the their parent dataset, and the pool name gets
listed multiple times instead of just once. With this, only the parent
dataset is counted. Future calls to create don't have the problem
regardless, because they look for the iohyve:name property rather than
looking for a dataset with /iohyve/ISO in its name.