### PR TITLE
issue# 216: Add support for bhyve's -u flag.

### DIFF
--- a/UPDATING
+++ b/UPDATING
@@ -1,3 +1,10 @@
+####Major changes for iohyve v0.7.7:
+
+- The `utc` property has been added to indicate that the `-u` flag should be passed
+	to bhyve so that bhyve's system clock is in UTC. The `create` command now sets
+	this property to `YES`, so the default behavior for a guest is for its system
+	clock to be in UTC, which is typically what is most appropriate for *nix OSes.
+
 ####There are two major changes in iohyve v0.7.5
 
 - The `fetch` command has been renamed to `fetchiso` to comply

--- a/lib/ioh-guest
+++ b/lib/ioh-guest
@@ -217,6 +217,7 @@ __guest_create() {
 		-o "iohyve:description=$description" \
 		-o iohyve:bargs=-A_-H_-P \
 		-o iohyve:template=NO \
+		-o iohyve:utc=YES \
 		-o iohyve:vnc=NO \
 		-o iohyve:vnc_ip=127.0.0.1 \
 		-o iohvye:vnc_port=5900 \
@@ -602,6 +603,7 @@ __guest_uefi() {
 	local fw="$(zfs get -H -o value iohyve:fw $dataset)"
 	local tap="$(zfs get -H -o value iohyve:tap $dataset)"
 	local bargs="$(zfs get -H -o value iohyve:bargs $dataset | sed -e 's/_/ /g')"
+	local utc="$(zfs get -H -o value iohyve:utc $dataset)"
 	local vnc="$(zfs get -H -o value iohyve:vnc $dataset)"
 	local vnc_ip="$(zfs get -H -o value iohyve:vnc_ip $dataset)"
 	local vnc_port="$(zfs get -H -o value iohyve:vnc_port $dataset)"
@@ -629,6 +631,12 @@ __guest_uefi() {
 		# Check to make sure guest isn't running
 		local running=$(pgrep -fx "bhyve: ioh-$name")
 		if [ -z $running ]; then
+			# build -u argument
+			if [ $utc = "YES" ]; then
+				utcline="-u"
+			else
+				utcline=""
+			fi
 			# Check for vnc
 			if [ $vnc = "YES" ]; then
 				# build vnc arguments
@@ -650,6 +658,7 @@ __guest_uefi() {
 					-s 10,virtio-net,$tap \
 					$vncline \
 					$tabletline \
+					$utcline \
 					-s 31,lpc \
 					-l com1,/dev/${con}A \
 					-l bootrom,/iohyve/Firmware/$fw/$fw \
@@ -660,6 +669,7 @@ __guest_uefi() {
 					-s 3,ahci-cd,/iohyve/ISO/$media/$media \
 					-s 4,ahci-hd,/dev/zvol/$dataset/disk0,sectorsize=512 \
 					-s 10,virtio-net,$tap \
+					$utcline \
 					-s 31,lpc \
 					-l com1,/dev/${con}A \
 					-l bootrom,/iohyve/Firmware/$fw/$fw \


### PR DESCRIPTION
This adds a zfs property for iohyve to manage the -u flag so that iohyve
can run a VM with its system clock in UTC.