### PR TITLE
Call proper setup_freenas function

### DIFF
--- a/lib/ioh-setup
+++ b/lib/ioh-setup
@@ -57,7 +57,7 @@ __setup_pool() {
 	if [ -e /etc/version ]; then
 		local OS=$( cat /etc/version | cut -d - -f1 )
 		if [ "$OS" = "FreeNAS" ]; then
-			setup_freenas $val
+			__setup_freenas $val
 		fi
 	fi
 }


### PR DESCRIPTION
The call to `setup_freenas` was missing the `__` prefix, thus resulting in an error and not actually calling the proper function.