### PR TITLE
Support of multiple tap interfaces for the guest.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ clone [-r] <name> <clonename>
 export <name>
 snaplist
 taplist
+tapadd <name> [iface]
+tapdel <name> <tap>
 activetaps
 conlist
 console <name>

--- a/iohyve
+++ b/iohyve
@@ -5,7 +5,6 @@
 # Set proper path thanks to iocage
 PATH=${PATH}:/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin
 
-
 # Check if libs are available (stolen from iocage)
 if [ -e "./lib/ioh-cmd" ] ; then
 	LIB="./lib"
@@ -75,6 +74,8 @@ iohyve  version
 	export <name>
 	snaplist
 	taplist
+        tapadd <name> [iface]
+        tapdel <name> <tap>
 	activetaps
 	conlist
 	console <name>

--- a/iohyve.8
+++ b/iohyve.8
@@ -45,6 +45,8 @@
 \fBiohyve\fP \fIexport\fP <name>
 \fBiohyve\fP \fIsnaplist\fP
 \fBiohyve\fP \fItaplist\fP
+\fBiohyve\fP \fItapladd\fP <name> [iface]
+\fBiohyve\fP \fItapldel\fP <name> <tap>
 \fBiohyve\fP \fIactivetaps\fP
 \fBiohyve\fP \fIconlist\fP
 \fBiohyve\fP \fIconsole\fP <name>
@@ -369,6 +371,18 @@ snapshots of \fIdisks\fP (they are there, though).
 \fItaplist\fP
 Lists all of the network taps taken by \fBiohyve\fP guests
 This will \fIlist\fP taps that are not active as well.
+.TP
+.B
+\fItapadd\fP
+Adds new network tap interface to the guest <name>.
+If [iface] is set, then new created network tap is assigned
+to the bridge, which contains network interface [iface].
+Otherwise the default network interface is used (network
+interface used during the setup)
+.TP
+.B
+\fItapdel\fP
+Remove network tap interface <tap> from the quest <name>.
 .TP
 .B
 \fIactivetaps\fP

--- a/iohyve.8.txt
+++ b/iohyve.8.txt
@@ -41,6 +41,8 @@ iohyve clone [-r] <name> <clonename>
 iohyve export <name>
 iohyve snaplist
 iohyve taplist
+iohyve tapadd <name> [iface]
+iohyve tapdel <name> <tap>
 iohyve activetaps
 iohyve conlist
 iohyve console <name>
@@ -282,7 +284,15 @@ snaplist	List all of the snapshots for all the guests. Does not show
 taplist		Lists all of the network taps taken by iohyve guests
 		This will list taps that are not active as well.
 
-activetaps	Lists all active taps in use
+tapadd		Adds new network tap interface to the guest <name>.
+		If [iface] is set, then new created network tap is assigned
+		to the bridge, which contains network interface [iface].
+		Otherwise the default network interface is used (network
+		interface used during the setup)
+
+tapdel		Remove network tap interface <tap> from the quest <name>.
+
+activetaps	Lists all active taps in use.
 
 conlist		Lists all of the nullmodem consoles taken by iohyve guests.
 		This will list taps that are not active as well.

--- a/lib/ioh-cmd
+++ b/lib/ioh-cmd
@@ -186,6 +186,14 @@ __parse_cmd () {
 				__tap_list
 				exit
 				;;
+			tapadd)
+				__tap_add "$@"
+				exit
+				;;
+			tapdel)
+				__tap_del "$@"
+				exit
+				;;
 			activetaps)
 				__tap_active_list
 				exit

--- a/lib/ioh-console
+++ b/lib/ioh-console
@@ -1,5 +1,15 @@
 #!/bin/sh
 
+# Returns last con id
+__console_last() {
+	local conlast="$(zfs get -H -o value iohyve:con | tr ',' '\n' | cut -c5- | sort -V | tail -n1)"
+	local con='0'
+	if [ -n "$conlast" ]; then
+		con="$(expr $conlast + 1)"
+	fi
+	echo $con
+}
+
 # List consoles in use
 __console_list() {
 	local pool="$(zfs list -H | grep iohyve | cut -d '/' -f 1 | head -n1)"

--- a/lib/ioh-guest
+++ b/lib/ioh-guest
@@ -178,38 +178,15 @@ __guest_create() {
 		exit 1
 	fi
 
-	local guestlist="$(zfs get -H -o name -t filesystem -s local,received iohyve:name)"
-	listtaps(){
-		for i in $guestlist ; do
-			local tapprop="$(zfs get -H -o value iohyve:tap $i)"
-			printf $tapprop'\n'
-		done
-	}
-	local taplast="$(listtaps | sort -V | cut -c4- | tail -n1)"
-	if [ -z "$taplast" ]; then
-		local tap='0'
-	else
-		local tap="$(expr $taplast + 1)"
-	fi
-	listcons(){
-		for i in $guestlist ; do
-			local conprop="$(zfs get -H -o value iohyve:con $i)"
-			printf $conprop'\n'
-		done
-	}
-	local conlast="$(listcons | sort -V | cut -c5- | tail -n1)"
-	if [ -z "$conlast" ]; then
-		local con='0'
-	else
-		local con="$(expr $conlast + 1)"
-	fi
+	local taplast="$(__tap_last)"
+	local conlast="$(__console_last)"
 	echo "Creating $name..."
 	zfs create -o iohyve:name=$name \
 		-o iohyve:size=$size \
 		-o iohyve:ram=256M \
 		-o iohyve:cpu=1 \
-		-o iohyve:tap=tap$tap \
-		-o iohyve:con=nmdm$con \
+		-o iohyve:tap=tap$taplast \
+		-o iohyve:con=nmdm$conlast \
 		-o iohyve:persist=1 \
 		-o iohyve:boot=0 \
 		-o iohyve:loader=bhyveload \
@@ -496,29 +473,14 @@ __guest_prepare() {
 	local dataset="$(zfs get -H -s local,received -o name,value -t filesystem iohyve:name | grep "$(printf '\t')$name$" | cut -f1)"
 	local pci="$(__zfs_get_pcidev_conf $dataset)"
 	# Setup tap if needed
-	local listtap="$(zfs get -H -o value iohyve:tap $dataset)"
-	for tap in $(echo $listtap | sed -n 1'p' | tr ',' '\n'); do
-		if [ $tap ] && [ $tap != "-" ]; then
-			local tapif="$(ifconfig -l | tr ' ' '\n' | grep -F -w $tap)"
-			if [ -z "$tapif" ]; then
-				# create tap interface
-				ifconfig $tap create descr "iohyve-$name"
-				ifconfig bridge0 addm $tap
-			fi
-			# Add a virtio-net pci device for the tap
-			local mac="$(zfs get -H -o value iohyve:mac_$tap $dataset)"
-			if [ $mac = "-" ]; then
-				pci="$pci virtio-net,$tap"
-			else
-				pci="$pci virtio-net,${tap},mac=${mac}"
-			fi
-		fi
-	done
-	#Add disk as second PCI device
+	__tap_setup $dataset
+	# Add tap interface
+	pci="$pci $(__tap_pci $dataset)"
+	# Add disk as second PCI device
 	pci="ahci-hd,/dev/zvol/$dataset/disk0 $pci"
-	#Add Hostbridge and lpc as the first PCI devices
+	# Add Hostbridge and lpc as the first PCI devices
 	pci="hostbridge lpc $pci"
-	# return the list of pci devices
+	# Return the list of pci devices
 	echo $pci
 }
 
@@ -601,7 +563,6 @@ __guest_uefi() {
 	local con="$(zfs get -H -o value iohyve:con $dataset)"
 	local cpu="$(zfs get -H -o value iohyve:cpu $dataset)"
 	local fw="$(zfs get -H -o value iohyve:fw $dataset)"
-	local tap="$(zfs get -H -o value iohyve:tap $dataset)"
 	local bargs="$(zfs get -H -o value iohyve:bargs $dataset | sed -e 's/_/ /g')"
 	local utc="$(zfs get -H -o value iohyve:utc $dataset)"
 	local vnc="$(zfs get -H -o value iohyve:vnc $dataset)"
@@ -613,13 +574,9 @@ __guest_uefi() {
 	local vnc_tablet="$(zfs get -H -o value iohyve:vnc_tablet $dataset)"
 	local pool="$(zfs list -H -t volume -o name | grep iohyve/$name | cut -d '/' -f1)"
 	# Create tap if needed
-	# check to see if tap is already created before attempting to create new tap interface
-	local tapif="$(ifconfig -l | tr ' ' '\n' | grep -F -w $tap)"
-	if [ -z "$tapif" ]; then
-		# create tap interface
-		ifconfig $tap create descr "iohyve-$name"
-		ifconfig bridge0 addm $tap
-	fi
+	__tap_setup $dataset
+	# Add tap interface
+	local tappci="$pci $(__tap_pci $dataset)"
 	# Make sure everything is in order...
 	if [ $fw = '-' ]; then
 		echo "You must set a firmware file property to use UEFI..."
@@ -655,7 +612,7 @@ __guest_uefi() {
 					-s 0,hostbridge \
 					-s 3,ahci-cd,/iohyve/ISO/$media/$media \
 					-s 4,ahci-hd,/dev/zvol/$dataset/disk0,sectorsize=512 \
-					-s 10,virtio-net,$tap \
+					-s 10,$tappci \
 					$vncline \
 					$tabletline \
 					$utcline \
@@ -668,7 +625,7 @@ __guest_uefi() {
 					-s 0,hostbridge \
 					-s 3,ahci-cd,/iohyve/ISO/$media/$media \
 					-s 4,ahci-hd,/dev/zvol/$dataset/disk0,sectorsize=512 \
-					-s 10,virtio-net,$tap \
+					-s 10,$tappci \
 					$utcline \
 					-s 31,lpc \
 					-l com1,/dev/${con}A \

--- a/lib/ioh-setup
+++ b/lib/ioh-setup
@@ -18,7 +18,7 @@ __setup() {
 		elif [ $prop = "net" ]; then
 			netval=$val
 		fi
-		
+
 	done
 
 	if [ -n "$( grep 'POPCNT' /var/run/dmesg.boot )" -o -n "$( grep 'POPCNT' /var/log/dmesg )" ]; then
@@ -34,7 +34,7 @@ __setup() {
 		echo "This may not end well for you."
 		echo "Other restrictions may apply."
 	fi
-	
+
 	# Run commands in correct order, so that the kernel modules are loaded
 	# before the network is setup
 	if [ -n "$poolval" ]; then
@@ -149,17 +149,45 @@ __load_kernel_modules() {
 	fi
 }
 
+__setup_bridge() {
+	local iface=$1
+	local bridgeif=""
+	local ifaceexist=$('ifconfig' -l | tr ' ' '\n' | grep "$iface")
+	if [ -n "$ifaceexist" ]; then
+		local allbridges=$('ifconfig' -l | tr ' ' '\n' | grep "bridge" | sort -V)
+		local lastbridge=$(echo $allbridges | tr ' ' '\n' | tail -n1 | cut -c7- )
+
+		for bridge in $allbridges; do
+			local bridgetest=$('ifconfig' $bridge | grep "member: $iface")
+			if [ -n "$bridgetest" ]; then
+				bridgeif=$bridge
+			fi
+		done
+
+		if [ -z "$bridgeif" ]; then
+			local nextbridge='0'
+			if [ -n "$lastbridge" ]; then
+				nextbridge="$(expr $lastbridge + 1)"
+			fi
+			bridgeif="bridge$nextbridge"
+
+			ifconfig $bridgeif create descr "iohyve-bridge-$iface"
+			ifconfig $bridgeif addm $iface
+			ifconfig $bridgeif up
+		fi
+	fi
+
+	echo $bridgeif
+}
+
 __setup_network() {
 	local iface=$1
-	local bridgeif="$('ifconfig' -l | grep -F "bridge0" | cut -c1)"
+	local bridgeif="$(__setup_bridge $iface)"
 	if [ -z "$bridgeif" ]; then
-		echo "Setting up bridge0 on $iface..."
-		if ! sysctl net.link.tap.up_on_open=1 > /dev/null 2>&1; then
-			echo "cannot set 'net.link.tap.up_on_open': is if_tap loaded?"
-		fi
-		ifconfig bridge0 create descr "iohyve-bridge" addm $iface up
+		echo "Setting up bridge with \"$iface\" failed!"
+		return 1
 	else
-		echo "bridge0 is already enabled on this machine..."
+		echo "bridge \"$bridgeif\" is already enabled on this machine..."
 		local sysctlexist
 		if ! sysctlexist="$(sysctl -n net.link.tap.up_on_open 2> /dev/null)"; then
 			echo "cannot set 'net.link.tap.up_on_open': is if_tap loaded?"
@@ -174,3 +202,4 @@ __setup_network() {
 		fi
 	fi
 }
+

--- a/lib/ioh-tap
+++ b/lib/ioh-tap
@@ -1,12 +1,156 @@
 #!/bin/sh
 
+# Returns last tap id
+__tap_last() {
+	local taplast="$(zfs get -H -o value iohyve:tap | tr ',' '\n' | cut -d '=' -f 1 | cut -c4- | sort -V | tail -n1)"
+	local tap='0'
+	if [ -n "$taplast" ]; then
+		tap="$(expr $taplast + 1)"
+	fi
+	echo $tap
+}
+
+# Returns cloned tap interface
+__tap_clone() {
+	local taps="$1"
+	local taplast="$(__tap_last)"
+	local tapsnew=""
+	for i in `echo $taps | tr ',' ' '`; do
+		local iface="$(echo $i | cut -d '=' -f 2 -s)"
+		if [ -z "$tapsnew" ]; then
+			tapsnew="tap$taplast"
+		else
+			tapsnew="$tapsnew,tap$taplast"
+		fi
+		if [ -n "$iface" ]; then
+			tapsnew="$tapsnew=$iface"
+		fi
+                taplast="$(expr $taplast + 1)"
+	done
+	echo $tapsnew
+}
+
+# Setup tap if needed
+__tap_setup() {
+	local dataset="$1"
+	local listtap="$(zfs get -H -o value iohyve:tap $dataset)"
+	for tapent in $(echo $listtap | sed -n 1'p' | tr ',' '\n'); do
+		local tap=$(echo $tapent | cut -d "=" -f 1)
+		local iface=$(echo $tapent | cut -d "=" -f 2 -s)
+		if [ -z "$iface" ]; then
+			iface="$(zfs get -H -o value iohyve:net $dataset)"
+		fi
+		local bridgeif=$(__setup_bridge $iface)
+		if [ -n "$tap" ] && [ "$tap" != "-" ] && [ -n "$bridgeif" ]; then
+			local tapif="$(ifconfig -l | tr ' ' '\n' | grep -F -w $tap)"
+			if [ -z $tapif ]; then
+				# create tap interface
+				ifconfig $tap create descr "iohyve-$name-$iface"
+				ifconfig $bridgeif addm $tap
+			fi
+		fi
+	done
+}
+
+# Returns virtio-net pci
+__tap_pci() {
+	local dataset="$1"
+	local pci=""
+	local listtap="$(zfs get -H -o value iohyve:tap $dataset)"
+	for tapent in $(echo $listtap | sed -n 1'p' | tr ',' '\n'); do
+		local tap=$(echo $tapent | cut -d "=" -f 1)
+		if [ -n "$tap" ] && [ "$tap" != "-" ]; then
+			# Add a virtio-net pci device for the tap
+			local mac="$(zfs get -H -o value iohyve:mac_$tap $dataset)"
+			if [ -z "$pci" ]; then
+				if [ $mac = "-" ]; then
+					pci="virtio-net,$tap"
+				else
+					pci="virtio-net,${tap},mac=${mac}"
+				fi
+			else
+				if [ $mac = "-" ]; then
+					pci="$pci virtio-net,$tap"
+				else
+					pci="$pci virtio-net,${tap},mac=${mac}"
+				fi
+			fi
+		fi
+	done
+	echo "$pci"
+}
+
+# Add tap to the dataset
+__tap_add() {
+	if [ $# -lt 2 ]; then
+		echo "Wrong number of parameters!"
+		__help
+		exit 1
+	fi
+
+	local name="$2"
+	local dataset="$(zfs list -H -t volume | grep $name | grep disk0 | cut -d '/' -f 1-3 | head -n1)"
+	if [ -z "$dataset" ]; then
+		echo "ERROR: dataset \"$name\" doesn't exist!"
+		exit 1
+	fi
+	local iface="$3"
+	if [ -z "$iface" ]; then
+		iface="$(zfs get -H -o value iohyve:net $dataset)"
+	fi
+	local listtap="$(zfs get -H -o value iohyve:tap $dataset)"
+	local tap="$(__tap_last)"
+
+	if [ -z "$listtap" ]; then
+		listtap="tap$tap=$iface"
+	else
+		listtap="$listtap,tap$tap=$iface"
+	fi
+	echo "Setting TAP parameters iohyve:tap=\"$listtap\" for the $dataset"
+	zfs set iohyve:tap="$listtap" $dataset
+}
+
+# Delete tap from the dataset
+__tap_del() {
+	if [ $# -lt 3 ]; then
+		echo "Wrong number of parameters!"
+		__help
+		exit 1
+	fi
+
+	local name="$2"
+	local tapname="$3"
+	local dataset="$(zfs list -H -t volume | grep $name | grep disk0 | cut -d '/' -f 1-3 | head -n1)"
+	if [ -z "$dataset" ]; then
+		echo "ERROR: dataset \"$name\" doesn't exist!"
+		exit 1
+	fi
+	local listtap="$(zfs get -H -o value iohyve:tap $dataset)"
+	local listtapnew=""
+	for tapent in $(echo $listtap | sed -n 1'p' | tr ',' '\n'); do
+		local tap=$(echo $tapent | cut -d "=" -f 1)
+		if [ "$tap" != "$tapname" ]; then
+			if [ -z "$listtapnew" ]; then
+				listtapnew="$tapent"
+			else
+				listtapnew="$listtapnew,$tapent"
+			fi
+		fi
+	done
+	if [ -z "$listtapnew" ]; then
+		listtapnew="-"
+	fi
+	echo "Setting TAP parameters iohyve:tap=\"$listtapnew\" for the $dataset"
+	zfs set iohyve:tap="$listtapnew" $dataset
+}
+
 # List taps in use
 __tap_list() {
 	local guestlist="$(zfs list -H -o name -t volume | grep iohyve | cut -d'/' -f1-3)"
 	echo "Listing all network taps:"
 	for i in $guestlist ; do
-		conprop="$(zfs get -H -o value iohyve:tap $i)"
-		printf $i'......'$conprop'\n'
+		tapprop="$(zfs get -H -o value iohyve:tap $i)"
+		printf $i'......'$tapprop'\n'
 	done
 }
 
@@ -15,3 +159,4 @@ __tap_active_list() {
   echo "Listing active network taps..."
 	ls /dev | grep tap
 }
+

--- a/lib/ioh-zfs
+++ b/lib/ioh-zfs
@@ -172,34 +172,12 @@ __zfs_cloneguest() {
 		zfs set iohyve:description=$description $pool/iohyve/$cname
 		# change con and tap properties to next available if -r is specified
 		if [ "$flag" == "-r" ]; then
-			local guestlist="$(zfs list -H -o name -t volume | grep iohyve | cut -d'/' -f1-3)"
-				listtaps(){
-					for i in $guestlist ; do
-						local tapprop="$(zfs get -H -o value iohyve:tap $i)"
-						printf $tapprop'\n'
-					done
-				}
-			local taplast="$(listtaps | sort -V | cut -c4- | tail -n1)"
-			if [ -z "$taplast" ]; then
-				local tap='0'
-			else
-				local tap="$(expr $taplast + 1)"
-			fi
-			listcons(){
-				for i in $guestlist ; do
-					local conprop="$(zfs get -H -o value iohyve:con $i)"
-					printf $conprop'\n'
-				done
-			}
-			local conlast="$(listcons | sort -V | cut -c5- | tail -n1)"
-			if [ -z "$conlast" ]; then
-				local con='0'
-			else
-				local con="$(expr $conlast + 1)"
-			fi
+			local taporig="$(zfs get -H -o value iohyve:tap $pool/iohyve/$name)"
+			local tapcloned="$(__tap_cloned $taporig)"
+			local conlast="$(__console_last)"
 
-			zfs set iohyve:tap=tap$tap $pool/iohyve/$cname
-			zfs set iohyve:con=nmdm$con $pool/iohyve/$cname
+			zfs set iohyve:tap=$tapcloned $pool/iohyve/$cname
+			zfs set iohyve:con=nmdm$conlast $pool/iohyve/$cname
 		fi
 	else
 		echo "Not a valid guest name"


### PR DESCRIPTION
Hi all,

I've updated the scripts to support multiple tap interfaces for the guest.
There is also support to assign network interface to the the tap interface. It can be used e.g. to assign tap interfaces to the different bridges.

This update is backward compatible for manipulating with old guest settings, but when it is used, old versions of the scripts are unusable.

BR, Radek