### PR TITLE
Stop counting pci device with number 30

### DIFF
--- a/lib/ioh-guest
+++ b/lib/ioh-guest
@@ -792,6 +792,9 @@ __guest_get_bhyve_cmd() {
 	for device in $devices ; do
 		echo "-s $pci_slot_count,$device"
 		pci_slot_count=$(( pci_slot_count + 1 ))
+                if [ $pci_slot_count -eq 31 ]; then
+                    break;
+                fi
 	done
 }
 

--- a/lib/ioh-zfs
+++ b/lib/ioh-zfs
@@ -12,7 +12,7 @@ __zfs_set() {
 	shift 2
 	for arg in "$@"; do
 		local prop="$(echo $arg | cut -d '=' -f1)"
-		local val="$(echo $arg | cut -d '=' -f2)"
+		local val="$(echo $arg | cut -d '=' -f2-)"
 		if [ $prop = "bargs" ]; then
 			local sval="$(echo $val | cut -d '"' -f2 | sed -e 's/ /_/g')"
 			echo "Setting $name $prop=$val..."


### PR DESCRIPTION
The pci slot value is defined as the range from 0 to 31. And if the LPC needs to be hard coded to "-s 31,lpc", we have to stop counting PCI devices with number 30