### PR TITLE
Typo in grub-bhyve command when os=debian

### DIFF
--- a/lib/ioh-guest
+++ b/lib/ioh-guest
@@ -328,7 +328,7 @@ __guest_load() {
 			elif [ $os = "debian" ]; then
 				printf '\(hd0\)\ /dev/zvol/'$disk'\n' > /iohyve/$name/device.map
 				printf '\(cd0\)\ '$media'\n' >> /iohyve/$name/device.map
-				grub-bhyve $wire_memory-m /iohyve/$name/device.map -r cd0  -c /dev/${con}A -M $ram ioh-$name
+				grub-bhyve $wire_memory -m /iohyve/$name/device.map -r cd0  -c /dev/${con}A -M $ram ioh-$name
 			elif [ $os = "d8lvm" ]; then
 				printf '\(hd0\)\ /dev/zvol/'$disk'\n' > /iohyve/$name/device.map
 				printf '\(cd0\)\ '$media'\n' >> /iohyve/$name/device.map


### PR DESCRIPTION
Just needed a space after `$wire_memory`. 