### PR TITLE
Add depth detection to rc script

### DIFF
--- a/rc.d/iohyve
+++ b/rc.d/iohyve
@@ -32,7 +32,16 @@ iohyve_start()
 
 		local bootprop="$(zfs get -H -o value iohyve:boot $dataset)"
 		if [ $bootprop = "1" ]; then
-			/usr/local/sbin/iohyve start $name
+			# Check dataset depth, used to ignore replication targets with boot=1 set
+			# normally dataset = "$pool/iohyve/$name"
+			depth="$(printf "$dataset" | grep -o "/" | wc -l)"
+			
+			if [ "$depth" -eq 2 ]; then
+				printf "Starting $dataset\n"
+				/usr/local/sbin/iohyve start $name
+			else
+				printf "Skipping $dataset: Guest has non-standard path\n"
+			fi
 		fi
 	done
 }


### PR DESCRIPTION
Skip autostarting guests set to boot when their dataset doesn't match a standard iohyve path.
(ex. "$pool/iohyve/$name").

This helps prevent autostarting guests that are stored on replicated datasets.
(ex. "$backup_pool/$original_pool/iohyve/$name").

Start Example:
Skipping backups/zpools/otherhost/iohyve/guest3: Guest has non-standard path
Skipping backups/zpools/otherhost/iohyve/guest4: Guest has non-standard path
Starting tank/iohyve/guest1
Starting tank/iohyve/guest2