### PR TITLE
Path filtering to support guest co-existence with zfs replicated backups.

### DIFF
--- a/lib/ioh-console
+++ b/lib/ioh-console
@@ -32,7 +32,7 @@ __console_console() {
 		exit 1
 	fi
 
-	local dataset="$(zfs get -H -s local,received -o name,value -t filesystem iohyve:name | grep "$(printf '\t')$name$" | cut -f1)"
+	local dataset="$(zfs get -H -s local,received -o name,value -t filesystem iohyve:name | cut -d '/' -f-3 | grep iohyve | grep "$(printf '\t')$name$" | cut -f1)"
 	local con="$(zfs get -H -o value iohyve:con $dataset)"
 	echo "Starting console on $name..."
 	echo "~~. to escape console [uses cu(1) for console]"

--- a/lib/ioh-guest
+++ b/lib/ioh-guest
@@ -9,7 +9,7 @@ __guest_list() {
 	fi
 	(
 	printf "%s^%s^%s^%s^%s\n" "Guest" "VMM?" "Running" "rcboot?" "Description"
-	local guests="$(zfs get -H -s local,received -o name,value -t filesystem iohyve:name | tr '\t' ',')"
+	local guests="$(zfs get -H -s local,received -o name,value -t filesystem iohyve:name | cut -d '/' -f-3 | grep iohyve | tr '\t' ',')"
 	for guest in $guests; do
 		local dataset="$(echo $guest | cut -f1 -d,)"
 		local name="$(echo $guest | cut -f2 -d,)"
@@ -54,7 +54,7 @@ __guest_info() {
 		pager="more"
 	fi
 	# Poll to see what pools have active guests
-	local guests="$(zfs get -H -s local,received -o name,value -t filesystem iohyve:name | tr '\t' ',')"
+	local guests="$(zfs get -H -s local,received -o name,value -t filesystem iohyve:name | cut -d '/' -f-3 | grep iohyve | tr '\t' ',')"
 
 	( # Begining of very large table of output.
 	# Print common header
@@ -167,10 +167,10 @@ __guest_info() {
 # Create guest
 __guest_create() {
 	local name="$2"
-	local pool="${4-$(zfs get -H -s local,received -o name -t filesystem iohyve:name | head -n1 | cut -f1 -d/)}"
+	local pool="${4-$(zfs get -H -s local,received -o name -t filesystem iohyve:name | cut -d '/' -f-3 | grep iohyve | head -n1 | cut -f1 -d/)}"
 	local size="$3"
 	if [ -z "$pool" ]; then
-		local pool="$(zfs list -H | grep /iohyve/ISO | grep -v /iohyve/ISO/ | cut -f1 -d/ |tail -n1)"
+		local pool="$(zfs list -H | cut -d '/' -f-3 | grep /iohyve/ISO | grep -v /iohyve/ISO/ | cut -f1 -d/ |tail -n1)"
 	fi
 	if [ -z "$size" ]; then
 		printf "missing argument\nusage:\n"
@@ -180,7 +180,7 @@ __guest_create() {
 	local description="$(date)"
 
 	# Check if guest with this name already exists
-	if [ -n "$(zfs get -H -o value -s local,received -t filesystem iohyve:name | grep ^$name$)" ]; then
+	if [ -n "$(zfs get -H -o value -s local,received -t filesystem iohyve:name | cut -d '/' -f-3 | grep iohyve | grep ^$name$)" ]; then
 		echo "Error: Guest with this name already exists"
 		exit 1
 	fi
@@ -241,7 +241,7 @@ __guest_install() {
 		return 1
 	fi
 
-	local dataset="$(zfs get -H -s local,received -o name,value -t filesystem iohyve:name | grep "$(printf '\t')$name$" | cut -f1)"
+	local dataset="$(zfs get -H -s local,received -o name,value -t filesystem iohyve:name | cut -d '/' -f-3 | grep iohyve | grep "$(printf '\t')$name$" | cut -f1)"
 	local mountpoint="$(zfs get -H -o value mountpoint $dataset)"
 	local loader="$(zfs get -H -o value iohyve:loader $dataset)"
 	# Check if guest is a template
@@ -302,8 +302,8 @@ __guest_load() {
 		return 1
 	fi
 
-	local disk="${3-$(zfs get -H -t volume -o name,value iohyve:name | grep "$(printf 'disk0\t')$name$" | cut -f1)}"
-	local dataset="$(zfs get -H -o name,value -s local,received -t filesystem iohyve:name | grep "$(printf '\t')$name$" | cut -f1)"
+	local disk="${3-$(zfs get -H -t volume -o name,value iohyve:name | cut -d '/' -f-4 | grep iohyve | grep "$(printf 'disk0\t')$name$" | cut -f1)}"
+	local dataset="$(zfs get -H -o name,value -s local,received -t filesystem iohyve:name | cut -d '/' -f-3 | grep iohyve | grep "$(printf '\t')$name$" | cut -f1)"
 	local ram="$(zfs get -H -o value iohyve:ram $dataset)"
 	local con="$(zfs get -H -o value iohyve:con $dataset)"
 	local loader="$(zfs get -H -o value iohyve:loader $dataset)"
@@ -467,7 +467,7 @@ __guest_boot() {
 	#   2 = always persist (start again even if guest is powering off)
 	local runmode="$2"
 	local pci="$3"
-	local dataset="$(zfs get -H -s local,received -o name,value -t filesystem iohyve:name | grep "$(printf '\t')$name$" | cut -f1)"
+	local dataset="$(zfs get -H -s local,received -o name,value -t filesystem iohyve:name | cut -d '/' -f-3 | grep iohyve | grep "$(printf '\t')$name$" | cut -f1)"
 	local ram="$(zfs get -H -o value iohyve:ram $dataset)"
 	local con="$(zfs get -H -o value iohyve:con $dataset)"
 	local cpu="$(zfs get -H -o value iohyve:cpu $dataset)"
@@ -517,7 +517,7 @@ __guest_boot() {
 
 __guest_prepare() {
 	local name="$1"
-	local dataset="$(zfs get -H -s local,received -o name,value -t filesystem iohyve:name | grep "$(printf '\t')$name$" | cut -f1)"
+	local dataset="$(zfs get -H -s local,received -o name,value -t filesystem iohyve:name | cut -d '/' -f-3 | grep iohyve | grep "$(printf '\t')$name$" | cut -f1)"
 	local pci="$(__zfs_get_pcidev_conf $dataset)"
 	# Setup tap if needed
 	__tap_setup $dataset
@@ -557,7 +557,7 @@ __guest_start() {
 	local flag="$3"
 	local pci=""
 	local runmode="1"
-	local dataset="$(zfs get -H -s local,received -o name,value -t filesystem iohyve:name | grep "$(printf '\t')$name$" | cut -f1)"
+	local dataset="$(zfs get -H -s local,received -o name,value -t filesystem iohyve:name | cut -d '/' -f-3 | grep iohyve | grep "$(printf '\t')$name$" | cut -f1)"
 	local loader="$(zfs get -H -o value iohyve:loader $dataset)"
 	# Check if guest is template
 	local template="$(zfs get -H -o value iohyve:template $dataset)"
@@ -614,7 +614,7 @@ __guest_uefi() {
 		return 1
 	fi
 
-	local dataset="$(zfs get -H -s local,received -o name,value -t filesystem iohyve:name | grep "$(printf '\t')$name$" | cut -f1)"
+	local dataset="$(zfs get -H -s local,received -o name,value -t filesystem iohyve:name | cut -d '/' -f-3 | grep iohyve | grep "$(printf '\t')$name$" | cut -f1)"
 	local ram="$(zfs get -H -o value iohyve:ram $dataset)"
 	local con="$(zfs get -H -o value iohyve:con $dataset)"
 	local cpu="$(zfs get -H -o value iohyve:cpu $dataset)"
@@ -773,7 +773,7 @@ __guest_rename() {
 		return 1
 	fi
 
-	local dataset="$(zfs get -H -o name,value -s local,received -t filesystem iohyve:name | grep "$(printf '\t')$name$" | cut -f1)"
+	local dataset="$(zfs get -H -o name,value -s local,received -t filesystem iohyve:name | cut -d '/' -f-3 | grep iohyve | grep "$(printf '\t')$name$" | cut -f1)"
 	# Check if guest is template
 	local template="$(zfs get -H -o value iohyve:template $dataset)"
 	if [ $template = "YES" ]; then
@@ -802,7 +802,7 @@ __guest_delete() {
 			return 1
 		fi
 
-		local target_dataset="$(zfs get -H -o name,value -s local,received -t filesystem iohyve:name | grep "$(printf '\t')$flagtwo$" | cut -f1)"
+		local target_dataset="$(zfs get -H -o name,value -s local,received -t filesystem iohyve:name | cut -d '/' -f-3 | grep iohyve | grep "$(printf '\t')$flagtwo$" | cut -f1)"
 		# Check if guest is template
 		local template="$(zfs get -H -o value iohyve:template $target_dataset)"
 		if [ $template = "YES" ]; then
@@ -829,7 +829,7 @@ __guest_delete() {
 			return 1
 		fi
 
-		local target_dataset="$(zfs get -H -o name,value -s local,received -t filesystem iohyve:name | grep "$(printf '\t')$flagone$" | cut -f1)"
+		local target_dataset="$(zfs get -H -o name,value -s local,received -t filesystem iohyve:name | cut -d '/' -f-3 | grep iohyve | grep "$(printf '\t')$flagone$" | cut -f1)"
 		# Check if guest is template
 		local template="$(zfs get -H -o value iohyve:template $target_dataset)"
 		if [ $template = "YES" ]; then
@@ -860,5 +860,5 @@ __guest_get_bhyve_cmd() {
 }
 
 __guest_exist() {
-	zfs get -H -s local,received -o value iohyve:name | grep ^$1$ > /dev/null
+	zfs get -H -s local,received -o name,value iohyve:name | cut -d '/' -f-3 | grep iohyve | cut -f2 | grep ^$1$ > /dev/null
 }

--- a/lib/ioh-zfs
+++ b/lib/ioh-zfs
@@ -8,7 +8,7 @@ __zfs_set() {
 		printf "\tset <name> <property=value> ...\n"
 		exit 1
 	fi
-	local pool="$(zfs list -H -t volume | grep iohyve/$name | cut -d '/' -f 1 | head -n1)"
+	local pool="$(zfs list -H -t volume | cut -d '/' -f-3 | grep iohyve/$name | cut -d '/' -f 1 | head -n1)"
 	shift 2
 	for arg in "$@"; do
 		local prop="$(echo $arg | cut -d '=' -f1)"
@@ -37,7 +37,7 @@ __zfs_get() {
 		printf "\tget <name> <prop>\n"
 		exit 1
 	fi
-	local pool="$(zfs list -H -t volume | grep iohyve/$name | cut -d '/' -f 1 | head -n1)"
+	local pool="$(zfs list -H -t volume | cut -d '/' -f-3 | grep iohyve/$name | cut -d '/' -f 1 | head -n1)"
 	echo "Getting $name prop $prop..."
 	zfs get -H -o value iohyve:$prop $pool/iohyve/$name
 }
@@ -55,7 +55,7 @@ __zfs_rmprop() {
 		fi
 		echo "Removing $flagthree from $flagtwo"
 		echo "I hope you picked the right property. Removing the wrong one can lead to bad things."
-		local pool="$(zfs list -H -t volume | grep $flagtwo | cut -d '/' -f 1 | head -n1)"
+		local pool="$(zfs list -H -t volume | cut -d '/' -f-3 | grep $flagtwo | cut -d '/' -f 1 | head -n1)"
 		zfs inherit  -r iohyve:$flagthree $pool/iohyve/$flagtwo
 	else
 		if [ -z "$flagtwo" ]; then
@@ -63,7 +63,7 @@ __zfs_rmprop() {
 			printf "\trmpci [-f] <name> <pcidev:N>\n"
 			exit 1
 		fi
-		local pool="$(zfs list -H -t volume | grep $flagone | cut -d '/' -f 1 | head -n1)"
+		local pool="$(zfs list -H -t volume | cut -d '/' -f-3 | grep $flagone | cut -d '/' -f 1 | head -n1)"
 		echo "Warning: Deleting the wrong property can lead to bad things."
 		read -p "Are you sure you want to remove $flagtwo [Y/N]? " an </dev/tty
 		case "$an" in
@@ -83,7 +83,7 @@ __zfs_getall() {
 		printf "\tgetall <name>\n"
 		exit 1
 	fi
-	local pool="$(zfs list -H -t volume | grep iohyve/$name | grep disk0 | cut -d '/' -f 1 | head -n1)"
+	local pool="$(zfs list -H -t volume | cut -d '/' -f-4 | grep iohyve/$name | grep disk0 | cut -d '/' -f 1 | head -n1)"
 	echo "Getting $name iohyve properties..."
 	zfs get -o property,value all $pool/iohyve/$name | grep iohyve: | sort | sed -e 's/iohyve://g'
 }
@@ -97,7 +97,7 @@ __zfs_snapguest() {
 		printf "\tsnap <name>@<snap>\n"
 		exit 1
 	fi
-	local pool="$(zfs list -H -t volume | grep iohyve/$name | grep disk0 | cut -d '/' -f 1 | head -n1)"
+	local pool="$(zfs list -H -t volume | cut -d '/' -f-4 | grep iohyve/$name | grep disk0 | cut -d '/' -f 1 | head -n1)"
 	echo "Taking snapshot $fullsnap"
 	# Check if guest exists
 	if [ -d /iohyve/$pool/$name ] || [ -d /iohyve/$name ]; then
@@ -111,14 +111,14 @@ __zfs_snapguest() {
 __zfs_rollguest() {
 	local fullsnap="$2"
 	local name="$(echo $fullsnap | cut -d '@' -f1)"
-	local pool="$(zfs list -H -t volume | grep iohyve/$name | grep disk0 | cut -d '/' -f 1 | head -n1)"
+	local pool="$(zfs list -H -t volume | cut -d '/' -f-4 | grep iohyve/$name | grep disk0 | cut -d '/' -f 1 | head -n1)"
 	local snap="$(echo $fullsnap | cut -d '@' -f2)"
 	if [ -z "$snap" ] || [ -z "$(echo $fullsnap | grep '@')" ]; then
 		printf "missing argument\nusage:\n"
 		printf "\troll <name>@<snap>\n"
 		exit 1
 	fi
-	local disklist="$(zfs list -H | grep iohyve/$name | grep disk | cut -f1 | cut -d '/' -f4-)"
+	local disklist="$(zfs list -H | cut -d '/' -f-4 | grep iohyve/$name | grep disk | cut -f1 | cut -d '/' -f4-)"
 	# Check if guest exists
 	echo "Rolling back to $fullsnap"
 	if [ -d /iohyve/$pool/$name ] || [ -d /iohyve/$name ]; then
@@ -155,7 +155,7 @@ __zfs_cloneguest() {
 	fi
 
 	local description="$(date | sed -e 's/ /_/g')"
-	local pool="$(zfs list -H -t volume | grep iohyve/$name | grep disk0 | cut -d '/' -f 1 | head -n1)"
+	local pool="$(zfs list -H -t volume | cut -d '/' -f-4 | grep iohyve/$name | grep disk0 | cut -d '/' -f 1 | head -n1)"
 	# Check if guest exists
 	echo "Cloning $name to $cname"
 	if [ -d /iohyve/$pool/$name ] || [ -d /iohyve/$name ]; then
@@ -192,8 +192,8 @@ __zfs_exportguest() {
 		printf "\texport <name>\n"
 		exit 1
 	fi
-	local pool="$(zfs list -H -t volume | grep $name | grep disk0 | cut -d '/' -f 1 | head -n1)"
-	local disklist="$(zfs list -H | grep iohyve | grep $name | grep disk | \
+	local pool="$(zfs list -H -t volume | cut -d '/' -f-4 | grep $name | grep disk0 | cut -d '/' -f 1 | head -n1)"
+	local disklist="$(zfs list -H | cut -d '/' -f-4 | grep iohyve | grep $name | grep disk | \
 				cut -f1 | cut -d '/' -f4-)"
 	# Check if guest exists
 	echo "Exporting $name. Note this may take some time depending on the size."
@@ -229,7 +229,7 @@ __zfs_exportguest() {
 
 # List all the snapshots
 __zfs_snaplist() {
-	zfs list -H -t snap | grep iohyve | grep -v disk | cut -f1 | cut -d '/' -f3
+	zfs list -H -t snap | cut -d '/' -f-3 | grep iohyve | grep '@' | grep -v disk | cut -f1 | cut -d '/' -f3
 }
 
 # Get PCI device config from zfs
@@ -238,7 +238,8 @@ __zfs_get_pcidev_conf() {
 	local oldifs=$IFS
 	#local pci
 	IFS=$'\n'
-	for pcidev in $(zfs get -H -o property,value all $pool | grep iohyve:pcidev: | sort )
+	# only display results of "filesystems" skipping properties on independent snapshots/volumes (many if autosnap enabled)
+	for pcidev in $(zfs get -H -o property,value -t filesystem all $pool | grep iohyve:pcidev: | sort )
 	do
 		echo $pcidev | cut -f2-
 	done


### PR DESCRIPTION
Similar to the filtering of pull request #257, filtering has been applied to additional functions. Expanded from rc init script to remaining functions. Additional code prevents guests of zfs filesystems with a depth greater than 3 from registering in variable assignments. This is primarily to support FreeNAS's ZFS replication feature to prevent backed up guests from causing duplicate name issues with original code.

Useable dataset (default for iohyve):
> $pool/iohyve/$guest
>
Filtered/Ignored dataset:
> $backup_pool/$original_pool/iohyve/$guest
>

Note: If manual zfs send/receive is used outside of FreeNAS replication, this will filter use of guests sent directly to another zpool without the use of a containing subfolder.