### PR TITLE
Fixes wrong already running/loaded messages.

### DIFF
--- a/lib/ioh-guest
+++ b/lib/ioh-guest
@@ -319,7 +319,7 @@ __guest_load() {
 		*) local wire_memory="" ;;
 	esac
 	# Check for loader already present as a zombie
-	if [ ! -z $(pgrep -f "ioh-$name") ]; then
+	if [ ! -z $(pgrep -xf "bhyve: ioh-$name") ]; then
 		echo "This guest appears to be already running/loaded."
 		echo "Use stop, destroy, or forcekill to remove zombie processes."
 		exit 1


### PR DESCRIPTION
Fix: This guest appears to be already running/loaded.

There is a race condition where iohyve will fail to start a bhyve
instance when there is a running iohyve with the prefix of the same name
as the iohyve you are trying to start.

e.g. (you have `example-other` running):

`iohyve start example`

Will fail with the error message:

```
This guest appears to be already running/loaded.
Use stop, destroy, or forcekill to remove zombie processes.
```

This corrects the pgrep regexs to stop matching past the name.
