### PR TITLE
Set the MTU on tap interfaces

### DIFF
--- a/lib/ioh-tap
+++ b/lib/ioh-tap
@@ -46,9 +46,13 @@ __tap_setup() {
 		fi
 		if [ -n "$tap" ] && [ "$tap" != "-" ] && [ -n "$bridgeif" ]; then
 			local tapif="$(ifconfig -l | tr ' ' '\n' | grep -F -w $tap)"
+			local mtu="$(ifconfig $bridgeif | egrep -io 'mtu [0-9]+' | cut -d ' ' -f 2)"
 			if [ -z "$tapif" ]; then
 				# create tap interface
 				ifconfig $tap create descr "iohyve-$name-$iface"
+				if [ -n "$mtu" ] ; then
+					ifconifg $tap mtu $mtu
+				fi
 				ifconfig $bridgeif addm $tap
 			fi
 		fi

--- a/lib/ioh-tap
+++ b/lib/ioh-tap
@@ -50,7 +50,7 @@ __tap_setup() {
 			if [ -z "$tapif" ]; then
 				# create tap interface
 				ifconfig $tap create descr "iohyve-$name-$iface"
-				if [ -n "$mtu" ] ; then
+				if [ -n "$mtu" ]; then
 					ifconifg $tap mtu $mtu
 				fi
 				ifconfig $bridgeif addm $tap


### PR DESCRIPTION
The MTU of tap interfaces must match the bridge they're added to. This PR makes the tap interface MTU match the bridge interface.

I ran into this when switching over to a larger MTU to get better throughput for services I'm testing. I found that I needed to manually set the MTU of the tap interfaces and add them to the bridge after starting guests. During startup, there'd be errors like `ifconfig: BRDGADD tap0: Invalid argument`.

I've tested this in a couple of cases, but it's certainly not exhaustively vetted.

Thanks! Hopefully it's worth the merge.
